### PR TITLE
Minor Patches and Fixes

### DIFF
--- a/Patches/ADE Pulse Turrets PLUS/Buildings_Security.xml
+++ b/Patches/ADE Pulse Turrets PLUS/Buildings_Security.xml
@@ -1,0 +1,222 @@
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>ADE Pulse Turrets</li>
+		</mods>
+		<match Class="PatchOperationSequence">		
+		<operations>
+		
+			<li Class="PatchOperationRemove">
+				<xpath>/Defs/ThingDef[
+					defName="ZXT_Turret_Pulsemachinegunturret" or
+					defName="ZXT_Turret_Sniperpulseturret" or
+					defName="ZXT_Turret_Armoredpowerpulseturret" or
+					defName="ZXT_Turret_Advancedrotarypulsemachinegunturret"
+				]/comps/li[@Class = "CompProperties_Refuelable"]</xpath>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[
+					defName="ZXT_Turret_Pulsemachinegunturret" or
+					defName="ZXT_Turret_Sniperpulseturret" or
+					defName="ZXT_Turret_Armoredpowerpulseturret" or
+					defName="ZXT_Turret_Advancedrotarypulsemachinegunturret"
+				]/thingClass</xpath>
+				<value>
+					<thingClass>CombatExtended.Building_TurretGunCE</thingClass>
+				</value>
+			</li>
+	<!-- Same label??? wth? -->
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[
+					defName="ZXT_Turret_Sniperpulseturret"
+				]/label</xpath>
+				<value>
+					<label>Armored Gauss Lance</label>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[
+					defName="ZXT_Turret_Pulsemachinegunturret" or
+					defName="ZXT_Turret_Sniperpulseturret" or
+					defName="ZXT_Turret_Armoredpowerpulseturret" or
+					defName="ZXT_Turret_Advancedrotarypulsemachinegunturret"
+				]/fillPercent</xpath>
+				<value>
+					<fillPercent>0.85</fillPercent>
+				</value>
+			</li>
+			
+			<!-- Increasing power requirement -->
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[
+					defName="ZXT_Turret_Pulsemachinegunturret" or
+					defName="ZXT_Turret_Sniperpulseturret" or
+					defName="ZXT_Turret_Armoredpowerpulseturret"
+				]/comps/li[@Class = "CompProperties_Power"]/basePowerConsumption</xpath>
+				<value>
+				<basePowerConsumption>1050</basePowerConsumption>
+				</value>
+			</li>		
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[
+					defName="ZXT_Turret_Advancedrotarypulsemachinegunturret"
+				]/comps/li[@Class = "CompProperties_Power"]/basePowerConsumption</xpath>
+				<value>
+				<basePowerConsumption>1450</basePowerConsumption>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[
+					defName="ZXT_Turret_Pulsemachinegunturret" or
+					defName="ZXT_Turret_Sniperpulseturret" or
+					defName="ZXT_Turret_Armoredpowerpulseturret" or
+					defName="ZXT_Turret_Advancedrotarypulsemachinegunturret" 
+				]/statBases/ShootingAccuracyTurret</xpath>
+				<value>
+					<AimingAccuracy>1</AimingAccuracy>
+					<ShootingAccuracyTurret>1</ShootingAccuracyTurret>
+				</value>
+			</li>
+			<!-- ========== Pulse HMG Turret ========== -->
+
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+				<defName>ZXT_Gun_Pulsemachinegunturret</defName>
+				<statBases>
+					<RangedWeapon_Cooldown>0.18</RangedWeapon_Cooldown>
+					<SightsEfficiency>1</SightsEfficiency>
+					<ShotSpread>0.05</ShotSpread>
+					<SwayFactor>1.03</SwayFactor>
+					<Bulk>37.08</Bulk>
+				</statBases>
+				<Properties>
+					<recoilAmount>0.55</recoilAmount>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>Bullet_8x35mmCharged</defaultProjectile>
+					<warmupTime>1.4</warmupTime>
+					<range>72</range>
+					<ticksBetweenBurstShots>3</ticksBetweenBurstShots>
+					<burstShotCount>10</burstShotCount>
+					<soundCast>Shot_ChargeBlaster</soundCast>
+					<soundCastTail>GunTail_Medium</soundCastTail>
+					<muzzleFlashScale>12</muzzleFlashScale>
+					<recoilPattern>Mounted</recoilPattern>
+				</Properties>
+				<FireModes>
+					<aiUseBurstMode>FALSE</aiUseBurstMode>
+					<aiAimMode>AimedShot</aiAimMode>
+					<noSnapshot>true</noSnapshot>
+					<noSingleShot>true</noSingleShot>					
+				</FireModes>				
+			</li>
+
+
+			<!-- ========== Charged SNiper Pulse Turret ========== -->
+
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+				<defName>ZXT_Gun_Sniperpulseturret</defName>
+				<statBases>
+					<RangedWeapon_Cooldown>0.55</RangedWeapon_Cooldown>
+					<SightsEfficiency>1.00</SightsEfficiency>
+					<ShotSpread>0.01</ShotSpread>
+					<SwayFactor>1.02</SwayFactor>
+					<Bulk>10.66</Bulk>
+				</statBases>
+				<Properties>
+					<recoilAmount>2.51</recoilAmount>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>Bullet_12mmRailgun_Sabot</defaultProjectile>
+					<warmupTime>1.6</warmupTime>
+					<range>102</range>
+					<ticksBetweenBurstShots>10</ticksBetweenBurstShots>
+					<burstShotCount>1</burstShotCount>
+					<soundCast>ChargeLance_Fire</soundCast>
+					<soundCastTail>GunTail_Medium</soundCastTail>
+					<muzzleFlashScale>45</muzzleFlashScale>
+					<recoilPattern>Mounted</recoilPattern>
+					<requireLineOfSight>false</requireLineOfSight>
+					<targetParams>
+						<canTargetLocations>true</canTargetLocations>
+					</targetParams>
+				</Properties>
+				<FireModes>
+					<aiUseBurstMode>TRUE</aiUseBurstMode>
+					<aiAimMode>AimedShot</aiAimMode>
+					<noSnapshot>true</noSnapshot>
+					<noSingleShot>true</noSingleShot>
+				</FireModes>
+			</li>
+
+
+			<!-- ========== Armored Pulse Turrets, one caliber higher PLUS========== -->
+
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+				<defName>ZXT_Gun_Armoredpowerpulseturret</defName>
+				<statBases>
+					<RangedWeapon_Cooldown>0.25</RangedWeapon_Cooldown>
+					<SightsEfficiency>1</SightsEfficiency>
+					<ShotSpread>0.07</ShotSpread>
+					<SwayFactor>1.22</SwayFactor>
+					<Bulk>37.08</Bulk>
+				</statBases>
+				<Properties>
+					<recoilAmount>0.75</recoilAmount>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>Bullet_8x50mmCharged</defaultProjectile>
+					<warmupTime>1.4</warmupTime>
+					<range>78</range>
+					<ticksBetweenBurstShots>3</ticksBetweenBurstShots>
+					<burstShotCount>10</burstShotCount>
+					<soundCast>Shot_ChargeBlaster</soundCast>
+					<soundCastTail>GunTail_Medium</soundCastTail>
+					<muzzleFlashScale>22</muzzleFlashScale>
+					<recoilPattern>Mounted</recoilPattern>
+				</Properties>
+				<FireModes>
+					<aiUseBurstMode>FALSE</aiUseBurstMode>
+					<aiAimMode>AimedShot</aiAimMode>
+					<noSnapshot>true</noSnapshot>
+					<noSingleShot>true</noSingleShot>					
+				</FireModes>				
+			</li>
+		<!-- ========== Armored Gatling Gun, ========= -->
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+				<defName>ZXT_Gun_Advancedrotarypulsemachinegunturret</defName>
+				<statBases>
+					<RangedWeapon_Cooldown>0.25</RangedWeapon_Cooldown>
+					<SightsEfficiency>1</SightsEfficiency>
+					<ShotSpread>0.11</ShotSpread>
+					<SwayFactor>1.25</SwayFactor>
+					<Bulk>37.08</Bulk>
+				</statBases>
+				<Properties>
+					<recoilAmount>0.725</recoilAmount>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>Bullet_12x64mmCharged</defaultProjectile>
+					<warmupTime>1.25</warmupTime>
+					<range>77</range>
+					<ticksBetweenBurstShots>2</ticksBetweenBurstShots>
+					<burstShotCount>20</burstShotCount>
+					<soundCast>Shot_ChargeBlaster</soundCast>
+					<soundCastTail>GunTail_Medium</soundCastTail>
+					<muzzleFlashScale>22</muzzleFlashScale>
+					<recoilPattern>Mounted</recoilPattern>
+				</Properties>
+				<FireModes>
+					<aiUseBurstMode>FALSE</aiUseBurstMode>
+					<aiAimMode>AimedShot</aiAimMode>
+					<noSnapshot>true</noSnapshot>
+					<noSingleShot>true</noSingleShot>					
+				</FireModes>				
+			</li>
+
+		</operations>
+		</match>
+	</Operation>
+</Patch> 

--- a/Patches/ADE Pulse Turrets PLUS/Remove_Mod_Ammo.xml
+++ b/Patches/ADE Pulse Turrets PLUS/Remove_Mod_Ammo.xml
@@ -1,0 +1,22 @@
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>ADE Pulse Turrets</li>
+		</mods>
+		<match Class="PatchOperationSequence">		
+		<operations>
+			<li Class="PatchOperationRemove">
+				<xpath>/Defs/RecipeDef[
+					defName="ZXT_Make_Ammo_Mediumpulsebattery" or
+					defName="ZXT_Make_x_Ammo_Mediumpulsebattery"
+				]</xpath>
+			</li>
+			<li Class="PatchOperationRemove">
+				<xpath>/Defs/ThingDef[
+					defName="ZXT_Ammo_Mediumpulsebattery"
+				]</xpath>
+			</li>
+		</operations>
+		</match>
+	</Operation>
+</Patch> 

--- a/Patches/RH2 Faction - The Rangers/Rangers_CE_Patch_Apparel.xml
+++ b/Patches/RH2 Faction - The Rangers/Rangers_CE_Patch_Apparel.xml
@@ -1,6 +1,4 @@
-<?xml version="1.0" encoding="utf-8" ?>
  <Patch>
-  
     <Operation Class="PatchOperationFindMod">
 		<mods>
 		<li>[RH2] Faction: The Rangers</li>
@@ -11,14 +9,14 @@
         <!-- ========== In-built Shield Patch ========== -->
 
         <li Class="PatchOperationReplace">
-            <xpath>/Defs/ThingDef[defName="RHApparel_PowerArmor_Ranger"]/comps/li[@Class="JetPacks.CompProperties_ShieldBelt"]/EnergyShieldRechargeRate</xpath>
+            <xpath>/Defs/ThingDef[@ParentName="RHApparel_Armor_VigilanteBase"]/statBases/EnergyShieldRechargeRate</xpath>
             <value>
                 <EnergyShieldRechargeRate>0.075</EnergyShieldRechargeRate>
             </value>
         </li>
 
         <li Class="PatchOperationReplace">
-            <xpath>/Defs/ThingDef[defName="RHApparel_PowerArmor_Ranger"]/comps/li[@Class="JetPacks.CompProperties_ShieldBelt"]/EnergyShieldEnergyMax</xpath>
+            <xpath>/Defs/ThingDef[@ParentName="RHApparel_Armor_VigilanteBase"]/statBases/EnergyShieldEnergyMax</xpath>
             <value>
                 <EnergyShieldEnergyMax>0.75</EnergyShieldEnergyMax>
             </value>
@@ -84,7 +82,7 @@
             <equippedStatOffsets>
                 <PsychicSensitivity>-0.2</PsychicSensitivity>
                 <AimingAccuracy>0.15</AimingAccuracy>
-                <ToxicEnvironmentResistance>0.50</ToxicEnvironmentResistance>
+                <ToxicResistance>0.50</ToxicResistance>
                 <SmokeSensitivity>-1</SmokeSensitivity>
             </equippedStatOffsets>
             </value>
@@ -164,7 +162,7 @@
             <value>
             <equippedStatOffsets>
                 <CarryWeight>25</CarryWeight>
-                <ToxicEnvironmentResistance>0.50</ToxicEnvironmentResistance>
+                <ToxicResistance>0.50</ToxicResistance>
                 <MoveSpeed>0.4</MoveSpeed>
             </equippedStatOffsets>
             </value>

--- a/Patches/RH2 Faction - The Rangers/Rangers_CE_Patch_Melee.xml
+++ b/Patches/RH2 Faction - The Rangers/Rangers_CE_Patch_Melee.xml
@@ -3,7 +3,7 @@
 
   <Operation Class="PatchOperationFindMod">
     <mods>
-      <li>[RH2] Faction: The Rangers</li>
+		<li>[RH2] Faction: The Rangers</li>
     </mods>
     <match Class="PatchOperationSequence">
       <operations>

--- a/Patches/RH2 Faction - The Rangers/Rangers_CE_Patch_Pawns.xml
+++ b/Patches/RH2 Faction - The Rangers/Rangers_CE_Patch_Pawns.xml
@@ -2,7 +2,7 @@
 <Patch>
 	<Operation Class="PatchOperationFindMod">
 		<mods>
-      		<li>[RH2] Faction: The Rangers</li>
+		<li>[RH2] Faction: The Rangers</li>
 		</mods>
 		<match Class="PatchOperationSequence">
 			<operations>

--- a/Patches/RH2 Faction - The Rangers/Rangers_CE_Patch_Sharpshooter.xml
+++ b/Patches/RH2 Faction - The Rangers/Rangers_CE_Patch_Sharpshooter.xml
@@ -3,7 +3,7 @@
 
 	<Operation Class="PatchOperationFindMod">
 		<mods>
-			<li>[RH2] Faction: The Rangers</li>
+		<li>[RH2] Faction: The Rangers</li>
 		</mods>
 		<match Class="PatchOperationSequence">
 		<operations>

--- a/Patches/Risk of Rain UES Contact Light Armory/Risk_Of_Rain_Armor_Patches.xml
+++ b/Patches/Risk of Rain UES Contact Light Armory/Risk_Of_Rain_Armor_Patches.xml
@@ -1,0 +1,645 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+ <Operation Class="PatchOperationFindMod">
+    <mods>
+      <li>Risk of Rain: UES Contact Light Armory (Continued)</li>
+    </mods>
+    <match Class="PatchOperationSequence">
+      <success>Always</success>
+      <operations>
+        <!-- Add new layer coverage to all Helmets -->
+        <li Class="PatchOperationAdd">
+          <xpath>Defs/ThingDef[defName="RoRA_BladeMarine_Helmet" or defName="RoRA_Conscript_Helmet" or defName="RoRA_Enforcer_Helmet" or defName="RoRA_Miner_Helmet" or defName="RoRA_Engineer_Helmet" or defName="RoRA_Ranger_Helmet" or defName="RoRA_Specialist_Helmet"]/apparel/layers</xpath>
+          <value>
+            <li>OnHead</li>
+            <li>StrappedHead</li>
+            <li>MiddleHead</li>
+          </value>
+        </li>
+        <!-- Add SmokeSensitivity to all Helmets -->
+        <li Class="PatchOperationAdd">
+          <xpath>Defs/ThingDef[defName="RoRA_BladeMarine_Helmet" or defName="RoRA_Conscript_Helmet" or defName="RoRA_Enforcer_Helmet" or defName="RoRA_Miner_Helmet" or defName="RoRA_Engineer_Helmet" or defName="RoRA_Ranger_Helmet" or defName="RoRA_Specialist_Helmet"]/equippedStatOffsets</xpath>
+          <value>
+            <SmokeSensitivity>-1</SmokeSensitivity>
+          </value>
+        </li>
+        <!-- ================================ BLADEMARINE  ================================ -->
+        <li Class="PatchOperationReplace">
+          <!-- Blademarine Helmet -->
+          <xpath>Defs/ThingDef[defName="RoRA_BladeMarine_Helmet"]/statBases/MaxHitPoints</xpath>
+          <value>
+            <MaxHitPoints>260</MaxHitPoints>
+          </value>
+        </li>
+        <li Class="PatchOperationAdd">
+          <xpath>Defs/ThingDef[defName="RoRA_BladeMarine_Helmet"]/statBases</xpath>
+          <value>
+            <Bulk>4</Bulk>
+            <WornBulk>0.25</WornBulk>
+          </value>
+        </li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/ThingDef[defName="RoRA_BladeMarine_Helmet"]/statBases/ArmorRating_Sharp</xpath>
+          <value>
+            <ArmorRating_Sharp>23</ArmorRating_Sharp>
+          </value>
+        </li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/ThingDef[defName="RoRA_BladeMarine_Helmet"]/statBases/ArmorRating_Blunt</xpath>
+          <value>
+            <ArmorRating_Blunt>48</ArmorRating_Blunt>
+          </value>
+        </li>
+        <li Class="PatchOperationAdd">
+          <xpath>Defs/ThingDef[defName="RoRA_BladeMarine_Helmet"]/equippedStatOffsets</xpath>
+          <value>
+            <MeleeCritChance>0.20</MeleeCritChance>
+            <MeleeParryChance>0.25</MeleeParryChance>
+            <ToxicSensitivity>-0.20</ToxicSensitivity>
+          </value>
+        </li>
+        <li Class="PatchOperationReplace">
+          <!-- Blademarine Armor -->
+          <xpath>Defs/ThingDef[defName="RoRA_BladeMarine_Armor"]/statBases/MaxHitPoints</xpath>
+          <value>
+            <MaxHitPoints>490</MaxHitPoints>
+          </value>
+        </li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/ThingDef[defName="RoRA_BladeMarine_Armor"]/statBases/Mass</xpath>
+          <value>
+            <Mass>45</Mass>
+          </value>
+        </li>
+        <li Class="PatchOperationAdd">
+          <xpath>Defs/ThingDef[defName="RoRA_BladeMarine_Armor"]/statBases</xpath>
+          <value>
+            <Bulk>90</Bulk>
+            <WornBulk>12</WornBulk>
+          </value>
+        </li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/ThingDef[defName="RoRA_BladeMarine_Armor"]/statBases/ArmorRating_Sharp</xpath>
+          <value>
+            <ArmorRating_Sharp>25</ArmorRating_Sharp>
+          </value>
+        </li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/ThingDef[defName="RoRA_BladeMarine_Armor"]/statBases/ArmorRating_Blunt</xpath>
+          <value>
+            <ArmorRating_Blunt>48</ArmorRating_Blunt>
+          </value>
+        </li>
+        <li Class="PatchOperationAdd">
+          <xpath>Defs/ThingDef[defName="RoRA_BladeMarine_Armor"]/equippedStatOffsets</xpath>
+          <value>
+            <CarryWeight>75</CarryWeight>
+            <CarryBulk>10</CarryBulk>
+            <ToxicSensitivity>-0.20</ToxicSensitivity>
+            <MeleeCritChance>0.55</MeleeCritChance>
+            <MeleeParryChance>0.5</MeleeParryChance>
+          </value>
+        </li>
+        <li Class="PatchOperationAdd">
+          <xpath>Defs/ThingDef[defName="RoRA_BladeMarine_Armor"]/apparel/bodyPartGroups</xpath>
+          <value>
+            <li>Hands</li>
+            <li>Feet</li>
+          </value>
+        </li>
+        <li Class="PatchOperationAdd">
+          <xpath>Defs/ThingDef[defName="RoRA_BladeMarine_Armor"]/apparel/layers</xpath>
+          <value>
+            <li>Middle</li>
+          </value>
+        </li>
+        <!-- ================================ CONSCRIPT  ================================ -->
+        <li Class="PatchOperationReplace">
+          <!-- Conscript Helmet -->
+          <xpath>Defs/ThingDef[defName="RoRA_Conscript_Helmet"]/statBases/MaxHitPoints</xpath>
+          <value>
+            <MaxHitPoints>200</MaxHitPoints>
+          </value>
+        </li>
+        <li Class="PatchOperationAdd">
+          <xpath>Defs/ThingDef[defName="RoRA_Conscript_Helmet"]/statBases</xpath>
+          <value>
+            <Bulk>3</Bulk>
+            <WornBulk>0.25</WornBulk>
+          </value>
+        </li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/ThingDef[defName="RoRA_Conscript_Helmet"]/statBases/ArmorRating_Sharp</xpath>
+          <value>
+            <ArmorRating_Sharp>17</ArmorRating_Sharp>
+          </value>
+        </li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/ThingDef[defName="RoRA_Conscript_Helmet"]/statBases/ArmorRating_Blunt</xpath>
+          <value>
+            <ArmorRating_Blunt>39</ArmorRating_Blunt>
+          </value>
+        </li>
+        <li Class="PatchOperationAdd">
+          <xpath>Defs/ThingDef[defName="RoRA_Conscript_Helmet"]/equippedStatOffsets</xpath>
+          <value>
+            <AimingAccuracy>0.08</AimingAccuracy>
+            <ToxicSensitivity>-0.10</ToxicSensitivity>
+          </value>
+        </li>
+        <li Class="PatchOperationReplace">
+          <!-- Conscript Armor -->
+          <xpath>Defs/ThingDef[defName="RoRA_Conscript_Armor"]/statBases/MaxHitPoints</xpath>
+          <value>
+            <MaxHitPoints>440</MaxHitPoints>
+          </value>
+        </li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/ThingDef[defName="RoRA_Conscript_Armor"]/statBases/Mass</xpath>
+          <value>
+            <Mass>40</Mass>
+          </value>
+        </li>
+        <li Class="PatchOperationAdd">
+          <xpath>Defs/ThingDef[defName="RoRA_Conscript_Armor"]/statBases</xpath>
+          <value>
+            <Bulk>70</Bulk>
+            <WornBulk>10</WornBulk>
+          </value>
+        </li>
+        <li Class="PatchOperationRemove">
+          <xpath>Defs/ThingDef[defName="RoRA_Conscript_Armor"]/equippedStatOffsets/MoveSpeed</xpath>
+        </li>
+        <li Class="PatchOperationAdd">
+          <xpath>Defs/ThingDef[defName="RoRA_Conscript_Armor"]/equippedStatOffsets</xpath>
+          <value>
+            <CarryWeight>60</CarryWeight>
+            <CarryBulk>15</CarryBulk>
+            <ToxicSensitivity>-0.10</ToxicSensitivity>
+            <ReloadSpeed>0.5</ReloadSpeed>
+          </value>
+        </li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/ThingDef[defName="RoRA_Conscript_Armor"]/statBases/ArmorRating_Sharp</xpath>
+          <value>
+            <ArmorRating_Sharp>18</ArmorRating_Sharp>
+          </value>
+        </li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/ThingDef[defName="RoRA_Conscript_Armor"]/statBases/ArmorRating_Blunt</xpath>
+          <value>
+            <ArmorRating_Blunt>40</ArmorRating_Blunt>
+          </value>
+        </li>
+        <li Class="PatchOperationAdd">
+          <xpath>Defs/ThingDef[defName="RoRA_Conscript_Armor"]/apparel/bodyPartGroups</xpath>
+          <value>
+            <li>Hands</li>
+            <li>Feet</li>
+          </value>
+        </li>
+        <li Class="PatchOperationAdd">
+          <xpath>Defs/ThingDef[defName="RoRA_Conscript_Armor"]/apparel/layers</xpath>
+          <value>
+            <li>Middle</li>
+          </value>
+        </li>
+        <!-- ================================ ENFORCER helmet  ================================ -->
+        <li Class="PatchOperationReplace">
+          <!-- Enforcer Helmet -->
+          <xpath>Defs/ThingDef[defName="RoRA_Enforcer_Helmet"]/statBases/MaxHitPoints</xpath>
+          <value>
+            <MaxHitPoints>260</MaxHitPoints>
+          </value>
+        </li>
+        <li Class="PatchOperationAdd">
+          <xpath>Defs/ThingDef[defName="RoRA_Enforcer_Helmet"]/statBases</xpath>
+          <value>
+            <Bulk>6</Bulk>
+            <WornBulk>2</WornBulk>
+          </value>
+        </li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/ThingDef[defName="RoRA_Enforcer_Helmet"]/statBases/ArmorRating_Sharp</xpath>
+          <value>
+            <ArmorRating_Sharp>25</ArmorRating_Sharp>
+          </value>
+        </li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/ThingDef[defName="RoRA_Enforcer_Helmet"]/statBases/ArmorRating_Blunt</xpath>
+          <value>
+            <ArmorRating_Blunt>50</ArmorRating_Blunt>
+          </value>
+        </li>
+        <li Class="PatchOperationAdd">
+          <xpath>Defs/ThingDef[defName="RoRA_Enforcer_Helmet"]/equippedStatOffsets</xpath>
+          <value>
+            <Suppressability>-0.25</Suppressability>
+            <ToxicSensitivity>-0.20</ToxicSensitivity>
+          </value>
+        </li>
+        <li Class="PatchOperationReplace">
+          <!-- Emforcer Armor -->
+          <xpath>Defs/ThingDef[defName="RoRA_Enforcer_Armor"]/statBases/MaxHitPoints</xpath>
+          <value>
+            <MaxHitPoints>560</MaxHitPoints>
+          </value>
+        </li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/ThingDef[defName="RoRA_Enforcer_Armor"]/statBases/Mass</xpath>
+          <value>
+            <Mass>60</Mass>
+          </value>
+        </li>
+        <li Class="PatchOperationAdd">
+          <xpath>Defs/ThingDef[defName="RoRA_Enforcer_Armor"]/statBases</xpath>
+          <value>
+            <Bulk>100</Bulk>
+            <WornBulk>15</WornBulk>
+          </value>
+        </li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/ThingDef[defName="RoRA_Enforcer_Armor"]/statBases/ArmorRating_Sharp</xpath>
+          <value>
+            <ArmorRating_Sharp>29</ArmorRating_Sharp>
+          </value>
+        </li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/ThingDef[defName="RoRA_Enforcer_Armor"]/statBases/ArmorRating_Blunt</xpath>
+          <value>
+            <ArmorRating_Blunt>52</ArmorRating_Blunt>
+          </value>
+        </li>
+        <li Class="PatchOperationRemove">
+          <xpath>Defs/ThingDef[defName="RoRA_Enforcer_Armor"]/equippedStatOffsets/MoveSpeed</xpath>
+        </li>
+        <li Class="PatchOperationAdd">
+          <xpath>Defs/ThingDef[defName="RoRA_Enforcer_Armor"]/equippedStatOffsets</xpath>
+          <value>
+            <CarryWeight>90</CarryWeight>
+            <CarryBulk>15</CarryBulk>
+            <ToxicSensitivity>-0.20</ToxicSensitivity>
+            <Suppressability>-0.50</Suppressability>
+            <ReloadSpeed>0.25</ReloadSpeed>
+          </value>
+        </li>
+        <li Class="PatchOperationAdd">
+          <xpath>Defs/ThingDef[defName="RoRA_Enforcer_Armor"]/apparel/bodyPartGroups</xpath>
+          <value>
+            <li>Hands</li>
+            <li>Feet</li>
+          </value>
+        </li>
+        <li Class="PatchOperationAdd">
+          <xpath>Defs/ThingDef[defName="RoRA_Enforcer_Armor"]/apparel/layers</xpath>
+          <value>
+            <li>Middle</li>
+          </value>
+        </li>
+        <!-- ================================ ENGINEER  ================================ -->
+        <!-- Engineer Helmet -->
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/ThingDef[defName="RoRA_Engineer_Helmet"]/statBases/MaxHitPoints</xpath>
+          <value>
+            <MaxHitPoints>220</MaxHitPoints>
+          </value>
+        </li>
+        <li Class="PatchOperationAdd">
+          <xpath>Defs/ThingDef[defName="RoRA_Engineer_Helmet"]/statBases</xpath>
+          <value>
+            <Bulk>4</Bulk>
+            <WornBulk>0.25</WornBulk>
+          </value>
+        </li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/ThingDef[defName="RoRA_Engineer_Helmet"]/statBases/ArmorRating_Sharp</xpath>
+          <value>
+            <ArmorRating_Sharp>17</ArmorRating_Sharp>
+          </value>
+        </li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/ThingDef[defName="RoRA_Engineer_Helmet"]/statBases/ArmorRating_Blunt</xpath>
+          <value>
+            <ArmorRating_Blunt>42</ArmorRating_Blunt>
+          </value>
+        </li>
+        <li Class="PatchOperationAdd">
+          <xpath>Defs/ThingDef[defName="RoRA_Engineer_Helmet"]/equippedStatOffsets</xpath>
+          <value>
+            <ToxicSensitivity>-0.30</ToxicSensitivity>
+          </value>
+        </li>
+        <li Class="PatchOperationReplace">
+          <!-- Engineer Armor -->
+          <xpath>Defs/ThingDef[defName="RoRA_Engineer_Armor"]/statBases/MaxHitPoints</xpath>
+          <value>
+            <MaxHitPoints>440</MaxHitPoints>
+          </value>
+        </li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/ThingDef[defName="RoRA_Engineer_Armor"]/statBases/Mass</xpath>
+          <value>
+            <Mass>40</Mass>
+          </value>
+        </li>
+        <li Class="PatchOperationAdd">
+          <xpath>Defs/ThingDef[defName="RoRA_Engineer_Armor"]/statBases</xpath>
+          <value>
+            <Bulk>80</Bulk>
+            <WornBulk>10</WornBulk>
+          </value>
+        </li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/ThingDef[defName="RoRA_Engineer_Armor"]/statBases/ArmorRating_Sharp</xpath>
+          <value>
+            <ArmorRating_Sharp>19</ArmorRating_Sharp>
+          </value>
+        </li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/ThingDef[defName="RoRA_Engineer_Armor"]/statBases/ArmorRating_Blunt</xpath>
+          <value>
+            <ArmorRating_Blunt>48</ArmorRating_Blunt>
+          </value>
+        </li>
+        <li Class="PatchOperationRemove">
+          <xpath>Defs/ThingDef[defName="RoRA_Engineer_Armor"]/equippedStatOffsets/MoveSpeed</xpath>
+        </li>
+        <li Class="PatchOperationAdd">
+          <xpath>Defs/ThingDef[defName="RoRA_Engineer_Armor"]/equippedStatOffsets</xpath>
+          <value>
+            <CarryWeight>85</CarryWeight>
+            <CarryBulk>10</CarryBulk>
+            <ToxicSensitivity>-0.50</ToxicSensitivity>
+          </value>
+        </li>
+        <li Class="PatchOperationAdd">
+          <xpath>Defs/ThingDef[defName="RoRA_Engineer_Armor"]/apparel/bodyPartGroups</xpath>
+          <value>
+            <li>Hands</li>
+            <li>Feet</li>
+          </value>
+        </li>
+        <li Class="PatchOperationAdd">
+          <xpath>Defs/ThingDef[defName="RoRA_Engineer_Armor"]/apparel/layers</xpath>
+          <value>
+            <li>Middle</li>
+          </value>
+        </li>
+        <!-- ================================ SPECIALIST  ================================ -->
+        <!-- Specialist Helmet -->
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/ThingDef[defName="RoRA_Specialist_Helmet"]/statBases/MaxHitPoints</xpath>
+          <value>
+            <MaxHitPoints>220</MaxHitPoints>
+          </value>
+        </li>
+        <li Class="PatchOperationAdd">
+          <xpath>Defs/ThingDef[defName="RoRA_Specialist_Helmet"]/statBases</xpath>
+          <value>
+            <Bulk>6</Bulk>
+            <WornBulk>2</WornBulk>
+          </value>
+        </li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/ThingDef[defName="RoRA_Specialist_Helmet"]/statBases/ArmorRating_Sharp</xpath>
+          <value>
+            <ArmorRating_Sharp>22</ArmorRating_Sharp>
+          </value>
+        </li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/ThingDef[defName="RoRA_Specialist_Helmet"]/statBases/ArmorRating_Blunt</xpath>
+          <value>
+            <ArmorRating_Blunt>48</ArmorRating_Blunt>
+          </value>
+        </li>
+        <li Class="PatchOperationAdd">
+          <xpath>Defs/ThingDef[defName="RoRA_Specialist_Helmet"]/equippedStatOffsets</xpath>
+          <value>
+            <AimingAccuracy>0.25</AimingAccuracy>
+            <Suppressability>-0.15</Suppressability>
+            <ToxicSensitivity>-0.40</ToxicSensitivity>
+          </value>
+        </li>
+        <li Class="PatchOperationReplace">
+          <!-- Specialist Armor -->
+          <xpath>Defs/ThingDef[defName="RoRA_Specialist_Armor"]/statBases/MaxHitPoints</xpath>
+          <value>
+            <MaxHitPoints>520</MaxHitPoints>
+          </value>
+        </li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/ThingDef[defName="RoRA_Specialist_Armor"]/statBases/Mass</xpath>
+          <value>
+            <Mass>55</Mass>
+          </value>
+        </li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/ThingDef[defName="RoRA_Specialist_Armor"]/statBases/ArmorRating_Sharp</xpath>
+          <value>
+            <ArmorRating_Sharp>25</ArmorRating_Sharp>
+          </value>
+        </li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/ThingDef[defName="RoRA_Specialist_Armor"]/statBases/ArmorRating_Blunt</xpath>
+          <value>
+            <ArmorRating_Blunt>48</ArmorRating_Blunt>
+          </value>
+        </li>
+        <li Class="PatchOperationAdd">
+          <xpath>Defs/ThingDef[defName="RoRA_Specialist_Armor"]/statBases</xpath>
+          <value>
+            <Bulk>100</Bulk>
+            <WornBulk>15</WornBulk>
+          </value>
+        </li>
+        <li Class="PatchOperationRemove">
+          <xpath>Defs/ThingDef[defName="RoRA_Specialist_Armor"]/equippedStatOffsets/MoveSpeed</xpath>
+        </li>
+        <li Class="PatchOperationAdd">
+          <xpath>Defs/ThingDef[defName="RoRA_Specialist_Armor"]/equippedStatOffsets</xpath>
+          <value>
+            <CarryWeight>100</CarryWeight>
+            <CarryBulk>25</CarryBulk>
+            <ToxicSensitivity>-0.50</ToxicSensitivity>
+            <Suppressability>-0.35</Suppressability>
+            <ReloadSpeed>0.25</ReloadSpeed>
+          </value>
+        </li>
+        <li Class="PatchOperationAdd">
+          <xpath>Defs/ThingDef[defName="RoRA_Specialist_Armor"]/apparel/bodyPartGroups</xpath>
+          <value>
+            <li>Hands</li>
+            <li>Feet</li>
+          </value>
+        </li>
+        <li Class="PatchOperationAdd">
+          <xpath>Defs/ThingDef[defName="RoRA_Specialist_Armor"]/apparel/layers</xpath>
+          <value>
+            <li>Middle</li>
+          </value>
+        </li>
+        <!-- ================================ RANGER  ================================ -->
+        <li Class="PatchOperationReplace">
+          <!-- Ranger Helmet -->
+          <xpath>Defs/ThingDef[defName="RoRA_Ranger_Helmet"]/statBases/MaxHitPoints</xpath>
+          <value>
+            <MaxHitPoints>200</MaxHitPoints>
+          </value>
+        </li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/ThingDef[defName="RoRA_Ranger_Helmet"]/statBases/ArmorRating_Sharp</xpath>
+          <value>
+            <ArmorRating_Sharp>19</ArmorRating_Sharp>
+          </value>
+        </li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/ThingDef[defName="RoRA_Ranger_Helmet"]/statBases/ArmorRating_Blunt</xpath>
+          <value>
+            <ArmorRating_Blunt>40</ArmorRating_Blunt>
+          </value>
+        </li>
+        <li Class="PatchOperationAdd">
+          <xpath>Defs/ThingDef[defName="RoRA_Ranger_Helmet"]/statBases</xpath>
+          <value>
+            <Bulk>4</Bulk>
+            <WornBulk>0.25</WornBulk>
+          </value>
+        </li>
+        <li Class="PatchOperationReplace">
+          <!-- Ranger Armor -->
+          <xpath>Defs/ThingDef[defName="RoRA_Ranger_Armor"]/statBases/MaxHitPoints</xpath>
+          <value>
+            <MaxHitPoints>480</MaxHitPoints>
+          </value>
+        </li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/ThingDef[defName="RoRA_Ranger_Armor"]/statBases/Mass</xpath>
+          <value>
+            <Mass>40</Mass>
+          </value>
+        </li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/ThingDef[defName="RoRA_Ranger_Armor"]/statBases/ArmorRating_Sharp</xpath>
+          <value>
+            <ArmorRating_Sharp>20</ArmorRating_Sharp>
+          </value>
+        </li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/ThingDef[defName="RoRA_Ranger_Armor"]/statBases/ArmorRating_Blunt</xpath>
+          <value>
+            <ArmorRating_Blunt>42</ArmorRating_Blunt>
+          </value>
+        </li>
+        <li Class="PatchOperationAdd">
+          <xpath>Defs/ThingDef[defName="RoRA_Ranger_Armor"]/statBases</xpath>
+          <value>
+            <Bulk>70</Bulk>
+            <WornBulk>10</WornBulk>
+          </value>
+        </li>
+        <li Class="PatchOperationAdd">
+          <xpath>Defs/ThingDef[defName="RoRA_Ranger_Armor"]/equippedStatOffsets</xpath>
+          <value>
+            <CarryWeight>75</CarryWeight>
+            <CarryBulk>10</CarryBulk>
+          </value>
+        </li>
+        <li Class="PatchOperationAdd">
+          <xpath>Defs/ThingDef[defName="RoRA_Ranger_Armor"]/apparel/bodyPartGroups</xpath>
+          <value>
+            <li>Hands</li>
+            <li>Feet</li>
+          </value>
+        </li>
+        <li Class="PatchOperationAdd">
+          <xpath>Defs/ThingDef[defName="RoRA_Ranger_Armor"]/apparel/layers</xpath>
+          <value>
+            <li>Middle</li>
+          </value>
+        </li>
+        <!-- ================================ MINER  ================================ -->
+        <li Class="PatchOperationReplace">
+          <!-- Miner Helmet -->
+          <xpath>Defs/ThingDef[defName="RoRA_Miner_Helmet"]/statBases/MaxHitPoints</xpath>
+          <value>
+            <MaxHitPoints>200</MaxHitPoints>
+          </value>
+        </li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/ThingDef[defName="RoRA_Miner_Helmet"]/statBases/ArmorRating_Sharp</xpath>
+          <value>
+            <ArmorRating_Sharp>22</ArmorRating_Sharp>
+          </value>
+        </li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/ThingDef[defName="RoRA_Miner_Helmet"]/statBases/ArmorRating_Blunt</xpath>
+          <value>
+            <ArmorRating_Blunt>45</ArmorRating_Blunt>
+          </value>
+        </li>
+        <li Class="PatchOperationAdd">
+          <xpath>Defs/ThingDef[defName="RoRA_Miner_Helmet"]/statBases</xpath>
+          <value>
+            <Bulk>5</Bulk>
+            <WornBulk>1</WornBulk>
+          </value>
+        </li>
+        <li Class="PatchOperationReplace">
+          <!-- Miner Armor -->
+          <xpath>Defs/ThingDef[defName="RoRA_Miner_Armor"]/statBases/MaxHitPoints</xpath>
+          <value>
+            <MaxHitPoints>510</MaxHitPoints>
+          </value>
+        </li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/ThingDef[defName="RoRA_Miner_Armor"]/statBases/Mass</xpath>
+          <value>
+            <Mass>50</Mass>
+          </value>
+        </li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/ThingDef[defName="RoRA_Miner_Armor"]/statBases/ArmorRating_Sharp</xpath>
+          <value>
+            <ArmorRating_Sharp>23</ArmorRating_Sharp>
+          </value>
+        </li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/ThingDef[defName="RoRA_Miner_Armor"]/statBases/ArmorRating_Blunt</xpath>
+          <value>
+            <ArmorRating_Blunt>45</ArmorRating_Blunt>
+          </value>
+        </li>
+        <li Class="PatchOperationAdd">
+          <xpath>Defs/ThingDef[defName="RoRA_Miner_Armor"]/statBases</xpath>
+          <value>
+            <Bulk>95</Bulk>
+            <WornBulk>12</WornBulk>
+          </value>
+        </li>
+        <li Class="PatchOperationRemove">
+          <xpath>Defs/ThingDef[defName="RoRA_Miner_Armor"]/equippedStatOffsets/MoveSpeed</xpath>
+        </li>
+        <li Class="PatchOperationAdd">
+          <xpath>Defs/ThingDef[defName="RoRA_Miner_Armor"]/equippedStatOffsets</xpath>
+          <value>
+            <CarryWeight>90</CarryWeight>
+            <CarryBulk>20</CarryBulk>
+          </value>
+        </li>
+        <li Class="PatchOperationAdd">
+          <xpath>Defs/ThingDef[defName="RoRA_Miner_Armor"]/apparel/bodyPartGroups</xpath>
+          <value>
+            <li>Hands</li>
+            <li>Feet</li>
+          </value>
+        </li>
+        <li Class="PatchOperationAdd">
+          <xpath>Defs/ThingDef[defName="RoRA_Miner_Armor"]/apparel/layers</xpath>
+          <value>
+            <li>Middle</li>
+          </value>
+        </li>
+      </operations>
+    </match>
+  </Operation>
+</Patch>


### PR DESCRIPTION

## Additions

Fixes Wrong xpath in Rimmunation Rangers armor
Adds Compatibility with Risk of Rain UE Light Contact Armory
Adds Compatibility with ADE Pulse Turrets +
Please note that partial armoring has not been implemented so someone will need to balance these patches

## References

nil

## Reasoning

I got some free time :D

## Alternatives

Removed the ammo that the ADE Pulse Turret added and the RecipeDefs since we are using our own Ammo

## Testing

Check tests you have performed:
- [Y] Compiles without warnings
- [Y] Game runs without errors
- [-] (For compatibility patches) ...with and without patched mod loaded
- [-] Playtested a colony (specify how long)
